### PR TITLE
Remove `srcset` package from `package-lock.json`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9081,21 +9081,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/srcset": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/srcset/-/srcset-5.0.1.tgz",
-			"integrity": "sha512-/P1UYbGfJVlxZag7aABNRrulEXAwCSDo7fklafOQrantuPTDmYgijJMks2zusPCVzgW9+4P69mq7w6pYuZpgxw==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/stackback": {
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",


### PR DESCRIPTION
The `srcset` package was removed from the dependency list, as it is no longer required. This change helps streamline the package dependencies and reduces potential maintenance overhead.