### PR TITLE
Additional documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1875,6 +1875,307 @@ unsubscribe();
 </section>
 <section className="relative space-y-2">
 
+## TypeScript Support
+
+`con-estado` is built with TypeScript and provides comprehensive type safety throughout your application. 
+The library leverages TypeScript's type inference to provide a seamless development experience.
+
+</section>
+<section className="relative space-y-2">
+
+### Type Inference
+
+The library automatically infers types from your initial state:
+
+```typescript
+// State type is inferred from initialState
+const useStore = createConStore({
+  user: {
+    name: 'John',
+    age: 30,
+    preferences: {
+      theme: 'dark' as 'dark' | 'light',
+      notifications: true
+    }
+  },
+  todos: [
+    { id: 1, text: 'Learn con-estado', completed: false }
+  ]
+});
+
+// In components:
+function UserProfile() {
+  // userData is typed as { name: string, age: number }
+  const userData = useStore(({ state }) => ({
+    name: state.user.name,
+    age: state.user.age
+  }));
+
+  // Type error if you try to access non-existent properties
+  const invalid = useStore(({ state }) => state.user.invalid); // Typescript error. Returns `undefined`
+}
+```
+
+</section>
+<section className="relative space-y-2">
+
+### Path Type Safety
+
+When using path-based operations, TypeScript ensures you're using valid paths:
+
+```typescript
+function TodoApp() {
+  const [state, { set, commit }] = useCon({
+    todos: [{ id: 1, text: 'Learn TypeScript', completed: false }]
+  });
+
+  // Type-safe path operations
+  set('todos[0].completed', true); // Valid
+  set('todos[0].invalid', true);   // Type error - property doesn't exist
+
+  // Type-safe commit operations
+  commit('todos', ({ stateProp }) => {
+    stateProp[0].completed = true; // Valid
+    stateProp[0].invalid = true;   // Type error
+  });
+}
+```
+
+</section>
+<section className="relative space-y-2">
+
+### Custom Type Definitions
+
+For more complex scenarios, you can explicitly define your state types:
+
+```typescript
+interface User {
+  id: number;
+  name: string;
+  email: string;
+}
+
+interface AppState {
+  users: User[];
+  currentUser: User | null;
+  isLoading: boolean;
+}
+
+// Explicitly typed store
+const useStore = createConStore({
+  users: [],
+  currentUser: null,
+  isLoading: false
+} as AppState );
+```
+
+</section>
+<section className="relative space-y-2">
+
+### Exported Type Utilities
+
+The library exports several utility types to help with type definitions:
+
+```typescript
+import {
+  ConState,           // Immutable state type
+  ConStateKeys,       // String paths for state
+  ConStateKeysArray,  // Array paths for state
+  ConHistory,         // History type
+  ConHistoryStateKeys // String paths including history
+} from 'con-estado';
+
+// Example usage
+type MyState = { count: number; user: { name: string } };
+type StatePaths = ConStateKeys<MyState>; // 'count' | 'user' | 'user.name'
+```
+
+</section>
+<section className="relative space-y-2">
+
+## Performance Optimization
+
+`con-estado` uses Mutative for high performance updates, 
+but there are several techniques you can use to optimize your application further:
+
+</section>
+<section className="relative space-y-2">
+
+### Use Selectors for Targeted Updates
+
+Selectors prevent unnecessary re-renders by only updating components when selected data changes:
+
+```typescript
+// BAD: Component re-renders on any state change
+function UserCount() {
+  const [state] = useCon({ users: [], settings: {} });
+  return <div>User count: {state.users.length}</div>;
+}
+
+// GOOD: Component only re-renders when users array changes
+function UserCount() {
+  const [state, { useSelector }] = useCon({ users: [], settings: {} });
+  const userCount = useSelector(({ state }) => state.users.length);
+  return <div>User count: {userCount}</div>;
+}
+```
+
+</section>
+<section className="relative space-y-2">
+
+### Memoize Complex Computations
+
+For expensive computations, memoize the results:
+
+```typescript
+function FilteredList() {
+  const [state, { useSelector }] = useCon( { items: [], filter: '' }, );
+
+  // Computation only runs when dependencies change
+  const filteredItems = useSelector(({ state }) => {
+    console.log('Filtering items');
+    return state.items.filter(item => 
+      item.name.includes(state.filter)
+    ).map(item => <div key={item.id}>{item.name}</div>);
+  });
+
+  return (
+    <div>
+      {filteredItems}
+    </div>
+  );
+}
+```
+
+</section>
+<section className="relative space-y-2">
+
+### Use Path-Based Updates
+
+Update only the specific parts of state that change:
+
+```typescript
+// BAD: Creates new references for the entire state tree
+set('state', { ...state, user: { ...state.user, name: 'New Name' } });
+
+// GOOD: Only updates the specific path
+set('state.user.name', 'New Name');
+```
+
+</section>
+<section className="relative space-y-2">
+
+### Configure Mutation Options
+
+For performance-critical applications, you can adjust mutation options:
+
+```typescript
+const useStore = createConStore(initialState, {
+  mutOptions: {
+    enableAutoFreeze: false, // Disable freezing for better performance
+  }
+});
+```
+
+</section>
+<section className="relative space-y-2">
+
+## Comparison with Other Libraries
+
+</section>
+<section className="relative space-y-2">
+
+### con-estado vs Redux
+
+| Feature        | con-estado                   | Redux                              |
+|----------------|------------------------------|------------------------------------|
+| Boilerplate    | Minimal                      | Requires actions, reducers, etc.   |
+| Nested Updates | Direct path updates          | Requires manual spreading or immer |
+| TypeScript     | Built-in inference           | Requires extra setup               |
+| Middleware     | Lifecycle hooks              | Middleware system                  |
+| Learning Curve | Low to moderate              | Moderate to high                   |
+| Bundle Size    | Small                        | Larger with ecosystem              |
+| Performance    | Optimized for nested updates | General purpose                    |
+
+</section>
+<section className="relative space-y-2">
+
+### con-estado vs Zustand
+
+| Feature          | con-estado                   | Zustand                     |
+|------------------|------------------------------|-----------------------------|
+| API Style        | React-focused                | React + vanilla JS          |
+| Nested Updates   | Built-in path operations     | Manual or with immer        |
+| Selectors        | Built-in with type inference | Requires manual memoization |
+| History Tracking | Built-in                     | Not included                |
+| TypeScript       | Deep path type safety        | Basic type support          |
+
+</section>
+<section className="relative space-y-2">
+
+### con-estado vs Jotai/Recoil
+
+| Feature        | con-estado            | Jotai/Recoil            |
+|----------------|-----------------------|-------------------------|
+| State Model    | Object-based          | Atom-based              |
+| Use Case       | Nested state          | Fine-grained reactivity |
+| Learning Curve | Moderate              | Moderate to high        |
+| Debugging      | History tracking      | Dev tools               |
+| Performance    | Optimized for objects | Optimized for atoms     |
+
+</section>
+<section className="relative space-y-2">
+
+## Troubleshooting
+
+</section>
+<section className="relative space-y-2">
+
+### State Updates Not Reflected in UI
+
+**Problem**: You've updated state but don't see changes in your component.
+
+**Solutions**:
+1. Check if you're using selectors correctly
+2. Verify that you're not mutating state directly
+3. Ensure you're using the correct path in path-based operations
+
+```typescript
+// INCORRECT
+state.user.name = 'New Name'; // Direct mutation
+
+// CORRECT
+set('state.user.name', 'New Name');
+// OR
+commit('state.user', ({ stateProp }) => {
+  stateProp.name = 'New Name';
+});
+// OR
+commit('state.user.name', (props) => {
+  props.stateProp = 'New Name';
+});
+```
+
+</section>
+<section className="relative space-y-2">
+
+## Debugging Tips
+
+1. Use the history tracking to inspect state changes
+2. Add logging in lifecycle hooks:
+
+```typescript
+const useStore = createConStore(initialState, {
+  afterChange: (history) => {
+    console.log('State updated:', history.state);
+    console.log('Changes:', history.changes);
+  }
+});
+```
+
+</section>
+<section className="relative space-y-2">
+
 ## Credits to
 
 - [Mutative](https://mutative.js.org/) for efficient immutable updates

--- a/site/next.config.mjs
+++ b/site/next.config.mjs
@@ -2,6 +2,7 @@ import process from 'node:process';
 import bundleAnalyzer from '@next/bundle-analyzer';
 import pkg from '../package.json' with { type: 'json',};
 import createMDX from '@next/mdx';
+import remarkGfm from 'remark-gfm';
 
 const withBundleAnalyzer = bundleAnalyzer( {
 	enabled: process.env.ANALYZE === 'true',
@@ -52,7 +53,7 @@ const withMDX = createMDX( {
 	// Add markdown plugins here, as desired
 	options: {
 		format: 'mdx',
-		remarkPlugins: [],
+		remarkPlugins: [remarkGfm,],
 		rehypePlugins: [
 		],
 	},

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -29,6 +29,7 @@
 				"react": "19.1.0",
 				"react-dom": "19.1.0",
 				"react-syntax-highlighter": "15.6.1",
+				"remark-gfm": "^4.0.1",
 				"tailwind-merge": "3.2.0",
 				"tailwindcss": "4.1.4",
 				"typescript": "5.8.3"
@@ -4935,6 +4936,16 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/markdown-table": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+			"integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/math-intrinsics": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4943,6 +4954,48 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/mdast-util-find-and-replace": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+			"integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"escape-string-regexp": "^5.0.0",
+				"unist-util-is": "^6.0.0",
+				"unist-util-visit-parents": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+			"integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/mdast-util-find-and-replace/node_modules/unist-util-visit-parents": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+			"integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"unist-util-is": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
 			}
 		},
 		"node_modules/mdast-util-from-markdown": {
@@ -4963,6 +5016,107 @@
 				"micromark-util-symbol": "^2.0.0",
 				"micromark-util-types": "^2.0.0",
 				"unist-util-stringify-position": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-gfm": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+			"integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+			"license": "MIT",
+			"dependencies": {
+				"mdast-util-from-markdown": "^2.0.0",
+				"mdast-util-gfm-autolink-literal": "^2.0.0",
+				"mdast-util-gfm-footnote": "^2.0.0",
+				"mdast-util-gfm-strikethrough": "^2.0.0",
+				"mdast-util-gfm-table": "^2.0.0",
+				"mdast-util-gfm-task-list-item": "^2.0.0",
+				"mdast-util-to-markdown": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-gfm-autolink-literal": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+			"integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"ccount": "^2.0.0",
+				"devlop": "^1.0.0",
+				"mdast-util-find-and-replace": "^3.0.0",
+				"micromark-util-character": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-gfm-footnote": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+			"integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"devlop": "^1.1.0",
+				"mdast-util-from-markdown": "^2.0.0",
+				"mdast-util-to-markdown": "^2.0.0",
+				"micromark-util-normalize-identifier": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-gfm-strikethrough": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+			"integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"mdast-util-from-markdown": "^2.0.0",
+				"mdast-util-to-markdown": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-gfm-table": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+			"integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"devlop": "^1.0.0",
+				"markdown-table": "^3.0.0",
+				"mdast-util-from-markdown": "^2.0.0",
+				"mdast-util-to-markdown": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-gfm-task-list-item": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+			"integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"devlop": "^1.0.0",
+				"mdast-util-from-markdown": "^2.0.0",
+				"mdast-util-to-markdown": "^2.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -5192,6 +5346,127 @@
 				"micromark-util-subtokenize": "^2.0.0",
 				"micromark-util-symbol": "^2.0.0",
 				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-extension-gfm": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+			"integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+			"license": "MIT",
+			"dependencies": {
+				"micromark-extension-gfm-autolink-literal": "^2.0.0",
+				"micromark-extension-gfm-footnote": "^2.0.0",
+				"micromark-extension-gfm-strikethrough": "^2.0.0",
+				"micromark-extension-gfm-table": "^2.0.0",
+				"micromark-extension-gfm-tagfilter": "^2.0.0",
+				"micromark-extension-gfm-task-list-item": "^2.0.0",
+				"micromark-util-combine-extensions": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-gfm-autolink-literal": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+			"integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-sanitize-uri": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-gfm-footnote": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+			"integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+			"license": "MIT",
+			"dependencies": {
+				"devlop": "^1.0.0",
+				"micromark-core-commonmark": "^2.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-normalize-identifier": "^2.0.0",
+				"micromark-util-sanitize-uri": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-gfm-strikethrough": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+			"integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+			"license": "MIT",
+			"dependencies": {
+				"devlop": "^1.0.0",
+				"micromark-util-chunked": "^2.0.0",
+				"micromark-util-classify-character": "^2.0.0",
+				"micromark-util-resolve-all": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-gfm-table": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+			"integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+			"license": "MIT",
+			"dependencies": {
+				"devlop": "^1.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-gfm-tagfilter": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+			"integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-gfm-task-list-item": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+			"integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+			"license": "MIT",
+			"dependencies": {
+				"devlop": "^1.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
 			}
 		},
 		"node_modules/micromark-extension-mdx-expression": {
@@ -6606,6 +6881,24 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
+		"node_modules/remark-gfm": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+			"integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"mdast-util-gfm": "^3.0.0",
+				"micromark-extension-gfm": "^3.0.0",
+				"remark-parse": "^11.0.0",
+				"remark-stringify": "^11.0.0",
+				"unified": "^11.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/remark-mdx": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-3.1.0.tgz",
@@ -6647,6 +6940,21 @@
 				"mdast-util-to-hast": "^13.0.0",
 				"unified": "^11.0.0",
 				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/remark-stringify": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+			"integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"mdast-util-to-markdown": "^2.0.0",
+				"unified": "^11.0.0"
 			},
 			"funding": {
 				"type": "opencollective",

--- a/site/package.json
+++ b/site/package.json
@@ -24,6 +24,7 @@
 		"react": "19.1.0",
 		"react-dom": "19.1.0",
 		"react-syntax-highlighter": "15.6.1",
+		"remark-gfm": "4.0.1",
 		"tailwind-merge": "3.2.0",
 		"tailwindcss": "4.1.4",
 		"typescript": "5.8.3"

--- a/site/src/components/page/README.tsx
+++ b/site/src/components/page/README.tsx
@@ -166,6 +166,34 @@ const components: MDXComponents = {
 		}
 		return <Image {..._props} />;
 	},
+	table( props, ) {
+		const _props = {
+			...props,
+			className: 'w-full max-w-[800px]',
+		};
+		return <table {..._props} />;
+	},
+	td( props, ) {
+		const _props = {
+			...props,
+			className: 'px-2 border-r-1 border-r-solid border-r-white',
+		};
+		return <td {..._props} />;
+	},
+	th( props, ) {
+		const _props = {
+			...props,
+			className: 'px-2 border-r-1 border-r-solid border-r-white',
+		};
+		return <th {..._props} />;
+	},
+	tr( props, ) {
+		const _props = {
+			...props,
+			className: 'border-b-1 border-b-solid border-b-white',
+		};
+		return <tr {..._props} />;
+	},
 };
 
 export default function README() {


### PR DESCRIPTION
Add support for GitHub Flavored Markdown (GFM)

Enabled the `remark-gfm` plugin in Next.js to add support for GitHub Flavored Markdown (e.g., tables, strikethrough, task lists). Updated dependencies and implemented custom table styling in the README component for table elements.