### PR TITLE
Add `@remarks` usage and document batch update functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ Track and access previous state values:
 
 - **state**: Current immutable state object.
 - **prev**: The previous immutable `state` object before `state` was updated.
-- **initial**: Immutable immutable initial state it started as. It can be updated through `historyDraft` for re-sync purposes,
+- **initial**: Immutable initial state it started as. It can be updated through `historyDraft` for re-sync purposes,
 such as merging with server data into `initial` while `state` keeps client side data.
 - **prevInitial**: The previous immutable `initial` object before `initial` was updated.
 - **changes**: Immutable object that keeps track of deeply nested difference between the `state` and `initial` object.
@@ -397,6 +397,31 @@ function StateHistory() {
   </div>;
 }
 ```
+
+</section>
+<section className="relative space-y-2">`
+
+## Batch Updates
+
+In cases where you need to consecutively [`set`](#set), [`merge`](#merge), or [`reset`](#reset) data, 
+you probably don't want to trigger consecutive re-renders. In this case, you can batch these updates by calling them in
+[`commit`](#commit) or [`wrap`](#wrap)
+
+```ts
+// state.set.some.arr = [ { data: 0 }, ]
+commit( ({ state }) => {
+  // state.set.some.arr = [ { data: 0 }, { data: 1 }, ]
+  merge( 'state.set.some.arr', [ , {data: 1}, ] );
+  
+  // state.set.some.arr = []
+  set( 'state.set.some.arr', [] );
+  
+  // state.set.some.arr = [ { data: 0 }, ]
+  reset();
+});
+```
+
+This provides the convenience of using `merge`, `set`, or `reset` without having to worry about multiple re-renders.
 
 </section>
 <section className="relative space-y-2">

--- a/src/types/Setters.ts
+++ b/src/types/Setters.ts
@@ -93,6 +93,9 @@ type Set<
 	 * - Maintains immutable history tracking
 	 * - Type-safe for all update patterns
 	 *
+	 * @remarks
+	 * This method can be called within {@link Commit.commit commit} and {@link Wrap.wrap wrap}
+	 *
 	 * @throws {Error} When trying to access non-object/array properties with dot-bracket notation
 	 * @throws {Error} When path has out-of-bounds negative indices
 	 *
@@ -221,6 +224,9 @@ type Merge<
 	 * - Special characters in paths must be escaped in dot-bracket notation
 	 * - Maintains type safety across all merge patterns
 	 *
+	 * @remarks
+	 * This method can be called within {@link Commit.commit commit} and {@link Wrap.wrap wrap}
+	 *
 	 * @throws {Error} When trying to:
 	 * - Access non-object/array properties with dot-bracket notation
 	 * - Merge incompatible types (e.g., object into array)
@@ -298,7 +304,10 @@ type Commit<
 	 * - Maintains type safety across all update patterns
 	 * - Path-based commits support both array and dot notation
 	 * - Unlike wrap, executes immediately instead of returning a function
-	 * - Useful for synchronous state initialization and resets
+	 * - Useful for synchronous state initialization
+	 *
+	 * @remarks
+	 * This method can be called within {@link Commit.commit commit} and {@link Wrap.wrap wrap}
 	 *
 	 * @throws {Error} When trying to access non-object/array properties with dot-bracket notation
 	 * @throws {Error} When path has out-of-bounds negative indices
@@ -416,6 +425,9 @@ type Wrap<
 	 * - Path-based wrappers support both array and dot-bracket notation
 	 * - Useful for creating reusable parameterized state updates
 	 *
+	 * @remarks
+	 * This method can be called within {@link Commit.commit commit} and {@link Wrap.wrap wrap}
+	 *
 	 * @throws {Error} When trying to access non-object/array properties with dot-bracket notation
 	 * @throws {Error} When path has out-of-bounds negative indices
 	 *
@@ -483,7 +495,10 @@ export type Setters<
 	 * @remarks
 	 * This method is useful for restoring the state to its original configuration,
 	 * effectively discarding any modifications made since the initial state.
-  	 */
+	 *
+	 * @remarks
+	 * This method can be called within {@link Commit.commit commit} and {@link Wrap.wrap wrap}
+	 */
 	reset(): void
 }
 & Commit<S>


### PR DESCRIPTION
Added `@remarks` annotations in Setters methods to indicate compatibility with `commit` and `wrap`.

Updated the README to introduce batch update capabilities, reducing unnecessary re-renders during multiple consecutive operations.